### PR TITLE
Fix KeyError while retrieving value from self._opts

### DIFF
--- a/oslo_config/cfg.py
+++ b/oslo_config/cfg.py
@@ -3137,6 +3137,10 @@ class ConfigOpts(collections.Mapping):
                                       'option': real_opt_name,
                                       'group': log_real_group_name})
             opt_name = real_opt_name
+            if opt_name not in opts:
+                opt = ListOpt(real_opt_name)
+                opt_name = opt.dest
+
             if real_group_name:
                 group = self._get_group(real_group_name)
                 opts = group._opts


### PR DESCRIPTION
This happens when calling _get_opt_info with deprecated opt name. Retrieve opt
and use opt.dest instead to avoid KeyError.

Closes-Bug: #1774722
Change-Id: I97d690e05699a95157158371a2312fc70b9f78c8